### PR TITLE
Add override for import types

### DIFF
--- a/template/example/tsconfig.json
+++ b/template/example/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "strict": false,
         "rootDirs": ["./", "../"],
-        "types": ["./types.d.ts"]
+        "types": ["./types.d.ts", "../types/index.d.ts"]
     },
     "include": ["./**/*.ts", "./**/*.tsx"]
 }

--- a/template/example/types.d.ts
+++ b/template/example/types.d.ts
@@ -11,10 +11,4 @@ declare global {
     }
 }
 
-declare module '@mappable-world/mappable-types/import' {
-    interface Import {
-        (pkg: '%PACKAGE_NAME%'): Promise<typeof import('../src/index')>;
-    }
-}
-
 export {};

--- a/template/t_ttsconfig.json
+++ b/template/t_ttsconfig.json
@@ -2,7 +2,7 @@
     "extends": ["@mappable-world/mappable-cli"],
     "compilerOptions": {
         "lib": ["dom", "dom.iterable", "esnext"],
-        "typeRoots": ["./node_modules/@types", "./node_modules/@mappable-world"]
+        "typeRoots": ["./node_modules/@types", "./node_modules/@mappable-world", "./types"]
     },
     "include": ["./src", "./node_modules/@mappable-world/mappable-cli/index.d.ts"]
 }

--- a/template/types/index.d.ts
+++ b/template/types/index.d.ts
@@ -1,0 +1,7 @@
+declare module '@mappable-world/mappable-types/import' {
+    interface Import {
+        (pkg: '%PACKAGE_NAME%'): Promise<typeof import('../src/index')>;
+    }
+}
+
+export {};


### PR DESCRIPTION
Move `@mappable-world/mappable-types/import` override to generated package part from example.